### PR TITLE
Fix DuckDuckGo search links

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -44,6 +44,8 @@ dillo-3.1 [not released yet]
 +- Fix bookmarks DPI crash.
  - Fix OSX compilation issue with xembed.
    Patches: Johannes Hofmann
++- Fix DuckDuckGo search links
+   Patches: Rodrigo Arias Mallo <rodarima@gmail.com>
 
 -----------------------------------------------------------------------------
 

--- a/dillorc
+++ b/dillorc
@@ -157,7 +157,7 @@
 # You can enable multiple search_url strings at once and select from among
 # them at runtime, with the first being the default.
 # (the prefix serves to search from the Location Bar. e.g. "dd dillo image")
-search_url="dd DuckDuckGo (https) https://duckduckgo.com/lite/?kp=-1&q=%s"
+search_url="dd DuckDuckGo (https) https://duckduckgo.com/lite/?kp=-1&kd=-1&q=%s"
 search_url="Wikipedia http://www.wikipedia.org/w/index.php?search=%s&go=Go"
 search_url="Free Dictionary http://www.thefreedictionary.com/%s"
 search_url="Startpage (https) https://www.startpage.com/do/search?query=%s"

--- a/doc/user_help.html
+++ b/doc/user_help.html
@@ -314,7 +314,7 @@
    <p>
    Example, in dillorc:<br>
    <blockquote>
-    <code>search_url="dd Duckduckgo http://duckduckgo.com/lite/?kp=-1&amp;q=%s"</code>
+    <code>search_url="dd Duckduckgo http://duckduckgo.com/lite/?kp=-1&amp;kd=-1&amp;q=%s"</code>
    </blockquote>
    means you can reach the location bar (CTRL+L), then type:
    <blockquote>

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -18,7 +18,7 @@
 #define PREFS_FONT_CURSIVE    "URW Chancery L"
 #define PREFS_FONT_FANTASY    "DejaVu Sans" /* TODO: find good default */
 #define PREFS_FONT_MONOSPACE  "DejaVu Sans Mono"
-#define PREFS_SEARCH_URL      "dd http://duckduckgo.com/lite/?kp=-1&q=%s"
+#define PREFS_SEARCH_URL      "dd http://duckduckgo.com/lite/?kp=-1&kd=-1&q=%s"
 #define PREFS_NO_PROXY        "localhost 127.0.0.1"
 #define PREFS_SAVE_DIR        "/tmp/"
 #define PREFS_HTTP_REFERER    "host"


### PR DESCRIPTION
The DuckDuckGo service that redirects the links from the search page is returning a broken page for non-javascript browsers. They have a meta refresh tag in the body, instead of in the head.

Adding the kd=-1 argument causes the DuckDuckGo search results to point directly to the target page avoiding the redirection.

Fixes: #8 